### PR TITLE
Handle an edge case where a handler function throw synchronously

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,11 @@ const EventEmitterPrototype = {
             return prevListenerPromise.then((prevListenerResult) => {
                 listenersResults.push(prevListenerResult);
 
-                let currentListenerResult = currentListener.fn(...args);
+                try{
+                    let currentListenerResult = currentListener.fn(...args);
+                }catch(e){
+                    return Promise.reject(e);   
+                }
 
                 //this code handles synchronous (not returning Promise) and asynchronous listeners
                 if (typeof currentListenerResult === 'object' && typeof currentListenerResult.then === 'function') {


### PR DESCRIPTION
I worked with some code that accidentally threw an error synchronously (NOT with `Promise.reject`). The error was swallowed and it made debugging really hard! This should help solve the issue :)